### PR TITLE
flow: Fix vlan forwarding check with vlan filtering disabled

### DIFF
--- a/device.c
+++ b/device.c
@@ -134,9 +134,13 @@ int device_vlan_get_output(struct device *dev, int vid)
 
 bool device_vlan_state_forwarding(struct device *dev, int vid)
 {
+	struct bridge *br = device_get_br(dev);
 	int i;
 
 	if (!dev->vlan)
+		return true;
+
+	if (br && !br->vlan_enabled)
 		return true;
 
 	for (i = 0; i < dev->n_vlans; i++) {


### PR DESCRIPTION
Skip vlan forwarding check if a device belog to a bridge and vlan filtering is disabled.

Fixes: f67fc970b4e3 ("bridger: add VLAN state verification")