### PR TITLE
pflow: handle FDB port migration in pending flow processing

### DIFF
--- a/flow.c
+++ b/flow.c
@@ -84,9 +84,9 @@ void bridger_check_pending_flow(struct bridger_flow_key *key,
 	fdb_in = fdb_get(br, &fkey);
 
 	if (fdb_in && fdb_in->dev != dev) {
-		D("Skip pending flow: received on %s, but fdb entry is on %s\n",
-		  dev->ifname, fdb_in->dev->ifname);
-		return;
+		D("FDB port migration: %s moved from %s to %s\n",
+		  format_macaddr(fkey.addr), fdb_in->dev->ifname, dev->ifname);
+		fdb_set_device(fdb_in, dev);
 	}
 
 	if (dev->redirect_dev) {


### PR DESCRIPTION
When a wireless client roams between AP interfaces (e.g. from 5GHz phy0.1-ap0 to 2.4GHz phy0.0-ap0), the kernel bridge updates its FDB internally but may not always generate RTM_NEWNEIGH notifications for the port change. This leaves bridger's FDB and offload flows pointing to the old port.

Previously, bridger_check_pending_flow() would skip pending flows when traffic arrived on a port different from the FDB entry's device. This meant that while new upload-direction flows would never be created, the stale download-direction TC flower rules (installed on the upstream interface like lan2) would keep redirecting traffic to the old WiFi port, causing severe throughput degradation (1 Mbit/s).

Instead of skipping, detect this as a port migration event: call fdb_set_device() to update the FDB entry to the new device. This triggers fdb_clear_flows() which deletes all stale flows in both directions (including TC flower / PPE offload rules), then allows the pending flow to be processed normally and create fresh flows with the correct port.

This is the most robust approach because it detects migration directly from observing traffic on the wire, without depending on kernel netlink FDB change notifications.

Co-authored-by: Claude 4.6 <noreply@anthropic.com>