### PR TITLE
flow/fdb/bpf: fix stale flows on FDB port migration

### DIFF
--- a/bpf.c
+++ b/bpf.c
@@ -60,6 +60,26 @@ void bridger_bpf_flow_delete(struct bridger_flow *flow)
 	bpf_map_delete_elem(map_offload, &flow->key);
 }
 
+void bridger_bpf_flush_pending_by_dev(struct device *dev)
+{
+	unsigned int ifindex = device_ifindex(dev);
+	struct bridger_flow_key key = {}, next;
+
+	/*
+	 * Remove every pending_flows entry that arrived on the old interface.
+	 * Without this, stale entries trigger a backwards fdb_set_device() on
+	 * the same poll cycle, re-creating TC filters for the departed radio.
+	 * Keep 'key' at the last valid (non-deleted) entry so get_next_key
+	 * has a stable anchor after each deletion.
+	 */
+	while (bpf_map_get_next_key(map_pending, &key, &next) == 0) {
+		if (next.ifindex == ifindex)
+			bpf_map_delete_elem(map_pending, &next);
+		else
+			key = next;
+	}
+}
+
 void bridger_bpf_dev_policy_set(struct device *dev)
 {
 	struct bridger_policy_flow val = {};

--- a/bpf.h
+++ b/bpf.h
@@ -13,5 +13,6 @@ void bridger_bpf_dev_policy_set(struct device *dev);
 void bridger_bpf_flow_upload(struct bridger_flow *flow);
 void bridger_bpf_flow_update(struct bridger_flow *flow);
 void bridger_bpf_flow_delete(struct bridger_flow *flow);
+void bridger_bpf_flush_pending_by_dev(struct device *dev);
 
 #endif

--- a/fdb.c
+++ b/fdb.c
@@ -11,6 +11,13 @@ static int fdb_key_cmp(const void *k1, const void *k2, void *ptr)
 	return memcmp(k1, k2, sizeof(struct fdb_key));
 }
 
+static void fdb_delete_timer_cb(struct uloop_timeout *t)
+{
+	struct fdb_entry *f = container_of(t, struct fdb_entry, delete_timer);
+
+	fdb_delete(f->br, f);
+}
+
 void fdb_init(struct bridge *br)
 {
 	avl_init(&br->fdb, fdb_key_cmp, false, NULL);
@@ -29,6 +36,7 @@ struct fdb_entry *fdb_create(struct bridge *br, const struct fdb_key *key, struc
 
 	f = fdb_get(br, key);
 	if (f) {
+		uloop_timeout_cancel(&f->delete_timer);
 		fdb_set_device(f, dev);
 		return f;
 	}
@@ -37,6 +45,8 @@ struct fdb_entry *fdb_create(struct bridge *br, const struct fdb_key *key, struc
 	  key->vlan, format_macaddr(key->addr), dev ? dev->ifname : "(none)");
 
 	f = calloc(1, sizeof(*f));
+	f->delete_timer.cb = fdb_delete_timer_cb;
+	f->br = br;
 	memcpy(&f->key, key, sizeof(*key));
 	f->node.key = &f->key;
 	INIT_LIST_HEAD(&f->dev_list);
@@ -50,16 +60,27 @@ struct fdb_entry *fdb_create(struct bridge *br, const struct fdb_key *key, struc
 
 void fdb_delete(struct bridge *br, struct fdb_entry *f)
 {
+	uloop_timeout_cancel(&f->delete_timer);
 	D("Delete fdb vlan %d entry %s\n", f->key.vlan, format_macaddr(f->key.addr));
 	fdb_set_device(f, NULL);
 	avl_delete(&br->fdb, &f->node);
 	free(f);
 }
 
+void fdb_schedule_delete(struct bridge *br, struct fdb_entry *f)
+{
+	f->br = br;
+	uloop_timeout_set(&f->delete_timer, 2000);
+}
+
 void fdb_set_device(struct fdb_entry *f, struct device *dev)
 {
+	struct device *old_dev;
+
 	if (f->dev == dev)
 		return;
+
+	old_dev = f->dev;
 
 	if (f->dev)
 		D("Set fdb vlan %d entry %s device to %s\n",
@@ -71,6 +92,14 @@ void fdb_set_device(struct fdb_entry *f, struct device *dev)
 	f->dev = dev;
 	if (dev)
 		list_add(&f->dev_list, &dev->fdb_entries);
+
+	/*
+	 * Flush stale pending_flows entries for the old interface so they
+	 * cannot trigger a backwards migration on the same poll cycle and
+	 * re-create the TC filters we just deleted via fdb_clear_flows().
+	 */
+	if (old_dev && !old_dev->br && dev)
+		bridger_bpf_flush_pending_by_dev(old_dev);
 }
 
 void fdb_clear_flows(struct fdb_entry *f)

--- a/fdb.h
+++ b/fdb.h
@@ -12,12 +12,14 @@ struct fdb_key {
 
 struct fdb_entry {
 	struct avl_node node;
+	struct uloop_timeout delete_timer;
 
 	struct fdb_key key;
 	uint16_t ndm_state;
 	bool updated;
 	bool is_local;
 
+	struct bridge *br;
 	struct device *dev;
 	struct list_head dev_list;
 
@@ -29,6 +31,7 @@ void fdb_init(struct bridge *br);
 struct fdb_entry *fdb_get(struct bridge *br, const struct fdb_key *key);
 struct fdb_entry *fdb_create(struct bridge *br, const struct fdb_key *key, struct device *dev);
 void fdb_delete(struct bridge *br, struct fdb_entry *f);
+void fdb_schedule_delete(struct bridge *br, struct fdb_entry *f);
 void fdb_set_device(struct fdb_entry *f, struct device *dev);
 void fdb_clear_flows(struct fdb_entry *f);
 

--- a/flow.c
+++ b/flow.c
@@ -84,8 +84,16 @@ void bridger_check_pending_flow(struct bridger_flow_key *key,
 	fdb_in = fdb_get(br, &fkey);
 
 	if (fdb_in && fdb_in->dev != dev) {
-		D("Skip pending flow: received on %s, but fdb entry is on %s\n",
-		  dev->ifname, fdb_in->dev->ifname);
+		D("FDB port migration: %s moved from %s to %s\n",
+		  format_macaddr(fkey.addr), fdb_in->dev->ifname, dev->ifname);
+		fdb_set_device(fdb_in, dev);
+		/*
+		 * fdb_set_device() cleaned up the stale flows; return now and
+		 * let the pending flow from the real current interface create
+		 * the new flows.  Creating flows here risks installing filters
+		 * for a stale interface if this pending entry arrived out of
+		 * order (e.g., from the previous radio before the roam).
+		 */
 		return;
 	}
 

--- a/nl.c
+++ b/nl.c
@@ -351,8 +351,8 @@ handle_neigh(struct nlmsghdr *nh, bool add)
 
 	if (!add) {
 		f = fdb_get(br, &key);
-		if (f)
-			fdb_delete(br, f);
+		if (f && f->dev == dev)
+			fdb_schedule_delete(br, f);
 		return;
 	}
 


### PR DESCRIPTION
When a client moves between bridge ports, stale pending_flows entries can leave TC offload filters pointing at the old interface.  Commit 95125f0 ("flow: reject pending flows with mismatched fdb device") skipped mismatched pending flows instead of migrating the FDB, which avoids refresh errors but never clears the stale filters.

Additionally, pending_flows are processed in hash order, so a stale entry processed after fdb_set_device() can trigger backwards migration on the same poll cycle and re-install filters for the departed port.

This commonly shows up during WiFi band roaming (e.g. 2.4 GHz to 5 GHz on dual-band APs), but applies to any FDB port migration on a bridged interface.

- flow.c: migrate FDB when pending flow arrives on a different port
- bpf.c: flush pending_flows for an interface
- fdb.c: flush stale pending flows on migration; defer FDB deletion
- nl.c: schedule deferred FDB delete on neighbor removal